### PR TITLE
Improved Skopt NeptuneMonitor

### DIFF
--- a/neptunecontrib/monitoring/skopt.py
+++ b/neptunecontrib/monitoring/skopt.py
@@ -50,7 +50,7 @@ class NeptuneCallback:
                                 base_estimator='ET', n_calls=100, n_random_starts=10)
 
         You can explore an example experiment in Neptune:
-        https://ui.neptune.ai/o/shared/org/showroom/e/SHOW-1061/logs
+        https://ui.neptune.ai/o/shared/org/showroom/e/SHOW-1065/logs
     """
 
     def __init__(self, experiment=None, log_checkpoint=True):
@@ -110,7 +110,7 @@ def log_results(results, experiment=None, log_plots=True, log_pickle=True):
              sk_utils.log_results(results)
 
         You can explore an example experiment in Neptune:
-        https://ui.neptune.ai/o/shared/org/showroom/e/SHOW-1061/logs
+        https://ui.neptune.ai/o/shared/org/showroom/e/SHOW-1065/logs
      """
     _exp = experiment if experiment else neptune
 
@@ -134,38 +134,38 @@ def NeptuneMonitor(*args, **kwargs):
     return NeptuneCallback(*args, **kwargs)
 
 
-def _log_best_parameters(results, experiment=None):
+def _log_best_parameters(results, experiment):
     named_params = ([(dimension.name, param) for dimension, param in zip(results.space, results.x)])
     experiment.set_property('best_parameters', str(named_params))
 
 
-def _log_best_score(results, experiment=None):
+def _log_best_score(results, experiment):
     experiment.log_metric('best_score', results.fun)
 
 
-def _log_plot_convergence(results, experiment=None):
+def _log_plot_convergence(results, experiment, name='diagnostics'):
     fig, ax = plt.subplots()
     sk_plots.plot_convergence(results, ax=ax)
-    experiment.log_image('plot_convergence', fig)
+    experiment.log_image(name, fig)
 
 
-def _log_plot_regret(results, experiment=None):
+def _log_plot_regret(results, experiment, name='diagnostics'):
     fig, ax = plt.subplots()
     sk_plots.plot_regret(results, ax=ax)
-    experiment.log_image('plot_regret', fig)
+    experiment.log_image(name, fig)
 
 
-def _log_plot_evaluations(results, experiment=None):
+def _log_plot_evaluations(results, experiment, name='diagnostics'):
     fig = plt.figure(figsize=(16, 12))
     fig = axes2fig(sk_plots.plot_evaluations(results, bins=10), fig=fig)
-    experiment.log_image('plot_evaluations', fig)
+    experiment.log_image(name, fig)
 
 
-def _log_plot_objective(results, experiment=None):
+def _log_plot_objective(results, experiment, name='diagnostics'):
     try:
         fig = plt.figure(figsize=(16, 12))
         fig = axes2fig(sk_plots.plot_objective(results), fig=fig)
-        experiment.log_image('plot_objective', fig)
+        experiment.log_image(name, fig)
     except Exception as e:
         print('Could not create the objective chart due to error: {}'.format(e))
 
@@ -187,4 +187,4 @@ def _export_results_object(results):
 
 
 def _format_to_named_params(params, result):
-    return ([(dimension.name, param) for dimension, param in zip(result.space, params)])
+    return [(dimension.name, param) for dimension, param in zip(result.space, params)]

--- a/neptunecontrib/monitoring/skopt.py
+++ b/neptunecontrib/monitoring/skopt.py
@@ -19,6 +19,7 @@ import matplotlib.pyplot as plt
 import neptune
 import numpy as np
 import skopt.plots as sk_plots
+from skopt.utils import dump
 
 from neptunecontrib.monitoring.utils import axes2fig
 
@@ -175,12 +176,11 @@ def _log_results_object(results, experiment=None):
 
 def _export_results_object(results):
     from io import BytesIO
-    import skopt
 
     results.specs['args'].pop('callback', None)
 
     buffer = BytesIO()
-    skopt.dump(results, buffer, store_objective=False)
+    dump(results, buffer, store_objective=False)
     buffer.seek(0)
 
     return buffer

--- a/neptunecontrib/monitoring/skopt.py
+++ b/neptunecontrib/monitoring/skopt.py
@@ -40,16 +40,16 @@ class NeptuneCallback:
 
             neptune.create_experiment(name='optuna sweep')
 
-            neptune_callback = sk_utils.NeptuneMonitor()
+            neptune_callback = sk_utils.NeptuneCallback()
 
-        Run skopt training passing monitor as a a callback::
+        Run skopt training passing neptune_callback as a callback::
 
             ...
             results = skopt.forest_minimize(objective, space, callback=[neptune_callback],
                                 base_estimator='ET', n_calls=100, n_random_starts=10)
 
         You can explore an example experiment in Neptune:
-        TODO
+        https://ui.neptune.ai/o/shared/org/showroom/e/SHOW-1061/logs
     """
 
     def __init__(self, experiment=None, log_checkpoint=True):
@@ -94,17 +94,22 @@ def log_results(results, experiment=None, log_plots=True, log_pickle=True):
              results = skopt.forest_minimize(objective, space,
                                  base_estimator='ET', n_calls=100, n_random_starts=10)
 
-         Send best parameters to neptune::
+         Initialize Neptune::
 
-             import neptune
+            import neptune
+
+            neptune.init(api_token='ANONYMOUS',
+                         project_qualified_name='shared/showroom')
+            neptune.create_experiment(name='optuna sweep')
+
+         Send best parameters to Neptune::
+
              import neptunecontrib.monitoring.skopt as sk_utils
-
-             neptune.init(project_qualified_name='USER_NAME/PROJECT_NAME')
 
              sk_utils.log_results(results)
 
         You can explore an example experiment in Neptune:
-        TODO
+        https://ui.neptune.ai/o/shared/org/showroom/e/SHOW-1061/logs
      """
     _exp = experiment if experiment else neptune
 
@@ -124,7 +129,7 @@ def log_results(results, experiment=None, log_plots=True, log_pickle=True):
 def NeptuneMonitor(*args, **kwargs):
     message = """NeptuneMonitor was renamed to NeptuneCallback and will be removed in future releases.
     """
-    warnings(message)
+    warnings.warn(message)
     return NeptuneCallback(*args, **kwargs)
 
 
@@ -150,14 +155,14 @@ def _log_plot_regret(results, experiment=None):
 
 
 def _log_plot_evaluations(results, experiment=None):
-    fig = plt.figure()
+    fig = plt.figure(figsize=(16, 12))
     fig = axes2fig(sk_plots.plot_evaluations(results, bins=10), fig=fig)
     experiment.log_image('plot_evaluations', fig)
 
 
 def _log_plot_objective(results, experiment=None):
     try:
-        fig = plt.figure()
+        fig = plt.figure(figsize=(16, 12))
         fig = axes2fig(sk_plots.plot_objective(results), fig=fig)
         experiment.log_image('plot_objective', fig)
     except Exception as e:

--- a/neptunecontrib/monitoring/skopt.py
+++ b/neptunecontrib/monitoring/skopt.py
@@ -77,9 +77,9 @@ class NeptuneCallback:
 def log_results(results, experiment=None, log_plots=True, log_pickle=True):
     """Logs runs results and parameters to neptune.
 
-    Logs all hyperparameter optimization results to Neptune. Those include best score ('best_score' channel),
-    best parameters ('best_parameters' property), convergence plot ('diagnostics' channel),
-    evaluations plot ('diagnostics' channel), and objective plot ('diagnostics' channel).
+    Logs all hyperparameter optimization results to Neptune. Those include best score ('best_score' metric),
+    best parameters ('best_parameters' property), convergence plot ('diagnostics' log),
+    evaluations plot ('diagnostics' log), and objective plot ('diagnostics' log).
 
      Args:
          results('scipy.optimize.OptimizeResult'): Results object that is typically an

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def main():
     extras = {
         'bots': ['python-telegram-bot'],
         'hpo': ['scikit-optimize>=0.5.2', 'scipy'],
-        'monitoring': ['scikit-optimize>=0.5.2', 'sacred>=0.7.5', 'scikit-learn>=0.21.3',
+        'monitoring': ['scikit-optimize>=0.7.4', 'sacred>=0.7.5', 'scikit-learn>=0.21.3',
                        'scikit-plot>=0.3.7', 'seaborn>=0.8.1', 'aif360>=0.2.1', 'xgboost>=0.82',
                        'graphviz>=0.13.2'],
         'versioning': ['boto3', 'numpy'],


### PR DESCRIPTION
Added:
* logging checkpoints of results object every epoch
* logging regret plot after training is finished

Changed
* Renamed `NeptuneMonitor` to `NeptuneCallback`
* Dropped functions that log single objects and just left the `log_results` function
