### PR TITLE
XGBoost, Log tree is is None by default, adapted docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,9 +53,9 @@ copyright = '2020, Neptune Dev Team'
 author = 'Neptune Dev Team'
 
 # The short X.Y version
-version = '0.22'
+version = '0.24'
 # The full version, including alpha/beta/rc tags
-release = '0.22.0'
+release = '0.24.3'
 
 # -- General configuration ---------------------------------------------------
 

--- a/neptunecontrib/api/chart.py
+++ b/neptunecontrib/api/chart.py
@@ -133,7 +133,9 @@ def log_chart(name, chart, experiment=None):
             # "Dang! That path collection is out of this world. I totally don't know what to do with it yet!
             # Plotly can only import path collections linked to 'data' coordinates"
             with warnings.catch_warnings():
-                warnings.filterwarnings("error", category=UserWarning,
+                warnings.filterwarnings(
+                    "error",
+                    category=UserWarning,
                     message=".*Plotly can only import path collections linked to 'data' coordinates.*")
                 chart = tools.mpl_to_plotly(chart)
 

--- a/neptunecontrib/api/chart.py
+++ b/neptunecontrib/api/chart.py
@@ -140,10 +140,10 @@ def log_chart(name, chart, experiment=None):
                 chart = tools.mpl_to_plotly(chart)
 
             _exp.log_artifact(export_plotly_figure(chart), "charts/" + name + '.html')
-        except (ImportError):
+        except ImportError:
             print("Plotly not installed. Logging plot as an image.")
             _exp.log_artifact(export_matplotlib_figure(chart), "charts/" + name + '.png')
-        except (UserWarning):
+        except UserWarning:
             print("Couldn't convert Matplotlib plot to interactive Plotly plot. Logging plot as an image instead.")
             _exp.log_artifact(export_matplotlib_figure(chart), "charts/" + name + '.png')
 

--- a/neptunecontrib/monitoring/xgboost.py
+++ b/neptunecontrib/monitoring/xgboost.py
@@ -23,7 +23,7 @@ import xgboost as xgb
 def neptune_callback(log_model=True,
                      log_importance=True,
                      max_num_features=None,
-                     log_tree=(0,),
+                     log_tree=None,
                      experiment=None,
                      **kwargs):
     """XGBoost callback for Neptune experiments.
@@ -34,14 +34,23 @@ def neptune_callback(log_model=True,
     Check Neptune documentation for the `full example <https://docs.neptune.ai/integrations/xgboost.html>`_.
 
     Make sure you created an experiment before you start XGBoost training using ``neptune.create_experiment()``
-    (`check our docs <https://docs.neptune.ai/neptune-client/docs/project.html
+    (`check our docs <https://docs.neptune.ai/api-reference/neptune/projects/index.html
     #neptune.projects.Project.create_experiment>`_).
+
+    You need to install graphviz and graphviz Python interface for ``log_tree`` feature to work.
+    Check `Graphviz <https://graphviz.org/download/>`_ and
+    `Graphviz Python interface <https://graphviz.readthedocs.io/en/stable/manual.html#installation>`_
+    for installation info.
 
     Integration works with ``xgboost>=0.82``.
 
     Tip:
-        Use this `Google Colab <https://colab.research.google.com/github/neptune-ai/neptune-colab-examples
-        /blob/master/xgboost-integration.ipynb>`_ to try it without further ado.
+        Use this `Google Colab <https://colab.research.google.com//github/neptune-ai/neptune-examples/blob/master/integrations/xgboost/docs/Neptune-XGBoost.ipynb>`_
+        run it as a "`neptuner`" user - zero setup, it just works.
+
+    Note:
+        If you use early stopping, make sure to log model, feature importance and trees on your own.
+        Neptune logs these artifacts only after last iteration, which you may not reach because of early stop.
 
     Args:
         log_model (:obj:`bool`, optional, default is ``True``):
@@ -54,11 +63,10 @@ def neptune_callback(log_model=True,
         max_num_features (:obj:`int`, optional, default is ``None``):
             | Plot top ``max_num_features`` features on the importance plot.
             | If ``None``, plot all features.
-        log_tree (:obj:`list` of :obj:`int`, optional, default is ``[1,]``):
+        log_tree (:obj:`list` of :obj:`int`, optional, default is ``None``):
             | Log specified trees to Neptune as images after last boosting iteration.
             | If you run xgb.cv, log specified trees for each folds' booster.
-            | Default is to log first tree.
-            | If ``None``, do not log any tree.
+            | Default is ``None`` - do not log any tree.
         experiment (:obj:`neptune.experiments.Experiment`, optional, default is ``None``):
             | For advanced users only. Pass Neptune
               `Experiment <https://docs.neptune.ai/neptune-client/docs/experiment.html#neptune.experiments.Experiment>`_
@@ -78,10 +86,6 @@ def neptune_callback(log_model=True,
         or ``XGBClassifier.fit()``
         (`check docs <https://xgboost.readthedocs.io/en/latest/python/python_api.html?highlight=plot_tree
         #xgboost.XGBClassifier.fit>`_).
-
-    Note:
-        If you use early stopping, make sure to log model, feature importance and trees on your own.
-        Neptune logs these artifacts only after last iteration, which you may not reach because of early stop.
 
     Examples:
         ``xgb.train`` examples
@@ -115,11 +119,11 @@ def neptune_callback(log_model=True,
                                                max_num_features=None,
                                                log_tree=None)])
 
-            # log top 5 features per each folds' booster
+            # log top 3 features per each folds' booster and first tree
             xgb.cv(param, dtrain, num_boost_round=num_round, nfold=7,
                    callbacks=[neptune_callback(log_model=False,
                                                max_num_features=3,
-                                               log_tree=None)])
+                                               log_tree=[0,])])
 
         ``sklearn`` API examples
 

--- a/neptunecontrib/monitoring/xgboost.py
+++ b/neptunecontrib/monitoring/xgboost.py
@@ -42,10 +42,11 @@ def neptune_callback(log_model=True,
     `Graphviz Python interface <https://graphviz.readthedocs.io/en/stable/manual.html#installation>`_
     for installation info.
 
-    Integration works with ``xgboost>=0.82``.
+    Integration works with ``xgboost>=1.2.0``.
 
     Tip:
-        Use this `Google Colab <https://colab.research.google.com//github/neptune-ai/neptune-examples/blob/master/integrations/xgboost/docs/Neptune-XGBoost.ipynb>`_
+        Use this `Google Colab <https://colab.research.google.com//github/neptune-ai/neptune-examples/blob/master/
+        integrations/xgboost/docs/Neptune-XGBoost.ipynb>`_
         run it as a "`neptuner`" user - zero setup, it just works.
 
     Note:
@@ -157,7 +158,7 @@ def neptune_callback(log_model=True,
         try:
             neptune.get_experiment()
             _exp = neptune
-        except neptune.exceptions.NoExperimentContext:
+        except neptune.exceptions.NeptuneNoExperimentContextException:
             msg = 'No currently running Neptune experiment. \n'\
                   'To start logging to Neptune create experiment by using: `neptune.create_experiment()`. \n'\
                   'More info in the documentation: '\

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def main():
         'bots': ['python-telegram-bot'],
         'hpo': ['scikit-optimize>=0.5.2', 'scipy'],
         'monitoring': ['scikit-optimize>=0.7.4', 'sacred>=0.7.5', 'scikit-learn>=0.21.3',
-                       'scikit-plot>=0.3.7', 'seaborn>=0.8.1', 'aif360>=0.2.1', 'xgboost>=0.82', 'graphviz>=0.13.2'],
+                       'scikit-plot>=0.3.7', 'seaborn>=0.8.1', 'aif360>=0.2.1', 'xgboost>=0.82'],
         'versioning': ['boto3', 'numpy'],
         'viz': ['altair>=2.3.0', 'hiplot>=0.1.5'],
     }


### PR DESCRIPTION
* Log tree is not None by default
* Adapted docstring, so that they mention required extra installation.
* Dropped graphviz from `monitoring` module requirements.